### PR TITLE
feat: Adds support for deleting AMIs

### DIFF
--- a/delete_functions.py
+++ b/delete_functions.py
@@ -236,10 +236,10 @@ def delete_nat_gateway(arn):
         print(f"Nat gateway {nat_gateway_id} was already deleted")
         return
     try:
-        client.delete_nat_gateway(NatGatewayId=nat_gateway_id)
+        response = client.delete_nat_gateway(NatGatewayId=nat_gateway_id)
         print(f"Nat gateway {nat_gateway_id} deletion initiated")
         print("Waiting for NAT Gateway to complete deletion process...")
-        nat_deleted= client.get_waiter('nat_gateway_deleted')
+        nat_deleted = client.get_waiter('nat_gateway_deleted')
         nat_deleted.wait(
             NatGatewayIds=[nat_gateway_id],
             WaiterConfig={
@@ -248,6 +248,7 @@ def delete_nat_gateway(arn):
             }
         )
         print(f"Nat gateway {nat_gateway_id} has been fully deleted")
+        print(json.dumps(response, indent=4, default=str))
     except Exception as e:
         print(f"Nat gateway {nat_gateway_id} was not fully deleted: {e}")
         return

--- a/get_other_ids.py
+++ b/get_other_ids.py
@@ -1,0 +1,45 @@
+# import json
+import boto3
+
+
+def get_images(tag_key, tag_value):
+    client = boto3.client('ec2')
+    response = client.describe_images(
+        Owners=['self'],
+        Filters=[
+            {
+                'Name': f'tag:{tag_key}',
+                'Values': [tag_value]
+            }
+        ]
+    )
+
+    resources = []
+
+    ami_ids = [image['ImageId'] for image in response['Images']]
+    for ami in ami_ids:
+        resources.append({
+            "resource_type": "ami",
+            "resource_id": ami,
+            "service": "ec2",
+        })
+
+    for image in response['Images']:
+        for mapping in image.get('BlockDeviceMappings', []):
+            ebs = mapping.get('Ebs')
+            if ebs and 'SnapshotId' in ebs:
+                resources.append({
+                    "resource_type": "snapshot",
+                    "resource_id": ebs['SnapshotId'],
+                    "service": "ec2",
+                })
+
+    # print(json.dumps(resources, indent=4, default=str))
+    return resources
+
+def main():
+    get_images('delete', 'true')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
1. Adds support for deleting AMIs and associated snapshots
2. Adds logic to check for any security attached to VPCs before attempting to delete VPC, as well as deletes the SGs
3. Adds error handling to safely check EC2 instances in the event they are showing up in the resource-groups client but have been terminated for so long that they no longer have an ARN.
4. Introduces the get_other_resources function to get IDs/ARNs of resources that do not show up with the resource-groups client. Any functions to be called by this function should be placed in the get_other_ids.py file.