### PR TITLE
feat: Adds support for various items

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -4,7 +4,8 @@
     "elasticloadbalancingv2",
     "asgclient",
     "elbv2",
-    "apigatewayv2"
+    "apigatewayv2",
+    "enis"
 
   ]
 

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -5,7 +5,8 @@
     "asgclient",
     "elbv2",
     "apigatewayv2",
-    "enis"
+    "enis",
+    "elbs"
 
   ]
 

--- a/delete_functions.py
+++ b/delete_functions.py
@@ -786,8 +786,14 @@ def delete_s3_bucket(arn):
                     for marker in page.get('DeleteMarkers', []):
                         objects_to_delete.append({'Key': marker['Key'], 'VersionId': marker['VersionId']})
                     if objects_to_delete:
-                        client.delete_objects(Bucket=bucket_name, Delete={'Objects': objects_to_delete})
-
+                        response = client.delete_objects(Bucket=bucket_name, Delete={'Objects': objects_to_delete})
+                        errors = response.get('Errors', [])
+                        if errors:
+                            print(f"One or more objects in {bucket_name} encountered errors during the deletion process:")
+                            print(json.dumps(errors, indent=4, default=str))
+                            print("Bucket cannot be deleted at this time. Exiting...")
+                            print()
+                            return
 
             else:
                 paginator = client.get_paginator('list_objects_v2')

--- a/delete_functions.py
+++ b/delete_functions.py
@@ -684,6 +684,18 @@ def delete_elastic_load_balancer(arn):
                 for tg in forward_config.get("TargetGroups", []):
                     target_group_arns.add(tg['TargetGroupArn'])
 
+    print(f"Proceeding with deleting ELB {arn} will also delete the following listeners and target groups:\n")
+    for listener in listener_arns:
+        print(f"Listener: {listener}")
+    for tg in target_group_arns:
+        print(f"Target group: {tg}")
+    print()
+    delete_tgs_and_listeners = input("Proceed? (y/n): ")
+    if delete_tgs_and_listeners != 'y':
+        print("Skipping ELB deletion...")
+        return
+
+    print("Deleting target groups and listeners...")
     # Delete listeners
     for listener in listener_arns:
         response = client.delete_listener(ListenerArn=listener)

--- a/get_other_ids.py
+++ b/get_other_ids.py
@@ -1,3 +1,7 @@
+'''
+Gets IDs from resources that do not show up when using the 'resource-groups' client.
+'''
+
 # import json
 import boto3
 

--- a/main.py
+++ b/main.py
@@ -231,8 +231,8 @@ def main():
         print("Exiting...")
         return
 
-    prompt = input("Do you want to be prompted before deleting each resource? Selecting 'n' will delete all resources automatically. (y/n): \n")
-
+    prompt = input("Do you want to be prompted before deleting each resource? Selecting 'n' will delete all resources automatically. (y/n): ")
+    print()
 
     failed_deletions = []
 

--- a/main.py
+++ b/main.py
@@ -83,7 +83,21 @@ def parse_resource_by_type(resource):
 
 def order_resources_for_deletion(resources):
     # Networking resources that must follow a particular deletion order
-    networking_resources = [resource for resource in resources if "ec2" in resource["service"]]
+    ordered_networking_resources = [
+        resource for resource in resources
+        if ("ec2" in resource["service"]) and (
+            resource['resource_type'] in (
+                'vpcendpoint',
+                'natgateway',
+                'subnet',
+                'eip',
+                'internetgateway',
+                'routetable',
+                'vpc',
+                'transitgatewayattachment'
+            )
+        )
+    ]
     # Other resources that must follow a particlar deletion order
     ordered_non_networking_resources = [resource for resource in resources if "ec2" not in resource["service"]]
     non_ordered_resources = [resource for resource in ordered_non_networking_resources if resource["service"] not in ["elasticloadbalancingv2", "autoscaling"]]
@@ -94,14 +108,14 @@ def order_resources_for_deletion(resources):
     ordered_resources.extend([resource for resource in other_resources])
     ordered_resources.extend([resource for resource in ordered_non_networking_resources if "autoscaling" in resource["service"]])
     ordered_resources.extend([resource for resource in ordered_non_networking_resources if "elasticloadbalancingv2" in resource["service"]])
-    ordered_resources.extend([resource for resource in networking_resources if "instance" in resource["resource_type"]])
-    ordered_resources.extend([resource for resource in networking_resources if "vpcendpoint" in resource["resource_type"]])
-    ordered_resources.extend([resource for resource in networking_resources if "natgateway" in resource["resource_type"]])
-    ordered_resources.extend([resource for resource in networking_resources if "subnet" in resource["resource_type"]])
-    ordered_resources.extend([resource for resource in networking_resources if "eip" in resource["resource_type"]])
-    ordered_resources.extend([resource for resource in networking_resources if "internetgateway" in resource["resource_type"]])
-    ordered_resources.extend([resource for resource in networking_resources if "routetable" in resource["resource_type"]])
-    ordered_resources.extend([resource for resource in networking_resources if resource["resource_type"] == "vpc"])
+    ordered_resources.extend([resource for resource in ordered_networking_resources if "instance" in resource["resource_type"]])
+    ordered_resources.extend([resource for resource in ordered_networking_resources if "vpcendpoint" in resource["resource_type"]])
+    ordered_resources.extend([resource for resource in ordered_networking_resources if "natgateway" in resource["resource_type"]])
+    ordered_resources.extend([resource for resource in ordered_networking_resources if "subnet" in resource["resource_type"]])
+    ordered_resources.extend([resource for resource in ordered_networking_resources if "eip" in resource["resource_type"]])
+    ordered_resources.extend([resource for resource in ordered_networking_resources if "internetgateway" in resource["resource_type"]])
+    ordered_resources.extend([resource for resource in ordered_networking_resources if "routetable" in resource["resource_type"]])
+    ordered_resources.extend([resource for resource in ordered_networking_resources if resource["resource_type"] == "vpc"])
 
     return ordered_resources
 

--- a/main.py
+++ b/main.py
@@ -225,7 +225,7 @@ def main():
     print(f"\n{len(ordered_resources_for_deletion)} resources queued for deletion. \n")
 
     # Figure out how to make this clearer
-    delete = input("Are you sure you want to delete all of these resources? (y/n): \n")
+    delete = input("Are you sure you want to delete all of these resources? (y/n): ")
 
     if delete.lower() != 'y':
         print("Exiting...")
@@ -241,6 +241,7 @@ def main():
 
         if prompt.lower() == 'y':
             confirm = input(f"\nDo you want to delete the following resource?\n{json.dumps(resource, indent=4, default=str )}\n[y/n]?: ")
+            print()
             if confirm.lower() != 'y':
                 print(f"Skipping deletion of {resource_name}")
                 continue

--- a/main.py
+++ b/main.py
@@ -94,7 +94,8 @@ def order_resources_for_deletion(resources):
                 'internetgateway',
                 'routetable',
                 'vpc',
-                'transitgatewayattachment'
+                'transitgatewayattachment',
+                "instance"
             )
         )
     ]
@@ -107,7 +108,9 @@ def order_resources_for_deletion(resources):
     ordered_resources.extend([resource for resource in non_ordered_resources])
     ordered_resources.extend([resource for resource in other_resources])
     ordered_resources.extend([resource for resource in ordered_non_networking_resources if "autoscaling" in resource["service"]])
-    ordered_resources.extend([resource for resource in ordered_non_networking_resources if "elasticloadbalancingv2" in resource["service"]])
+    ordered_resources.extend([resource for resource in ordered_non_networking_resources if "loadbalancer" in resource["resource_type"]])
+    ordered_resources.extend([resource for resource in ordered_non_networking_resources if "listener" in resource["resource_type"]])
+    ordered_resources.extend([resource for resource in ordered_non_networking_resources if "targetgroup" in resource["resource_type"]])
     ordered_resources.extend([resource for resource in ordered_networking_resources if "instance" in resource["resource_type"]])
     ordered_resources.extend([resource for resource in ordered_networking_resources if "vpcendpoint" in resource["resource_type"]])
     ordered_resources.extend([resource for resource in ordered_networking_resources if "natgateway" in resource["resource_type"]])

--- a/main.py
+++ b/main.py
@@ -212,11 +212,13 @@ def main():
 
     # Figure out how to make this clearer
     delete = input("Are you sure you want to delete all of these resources? (y/n): \n")
-    prompt = input("Do you want to be prompted before deleting each resource? Selecting 'n' will delete all resources automatically. (y/n): \n")
 
     if delete.lower() != 'y':
         print("Exiting...")
         return
+
+    prompt = input("Do you want to be prompted before deleting each resource? Selecting 'n' will delete all resources automatically. (y/n): \n")
+
 
     failed_deletions = []
 


### PR DESCRIPTION
1. Fixes and improves logic for VPC links. Function now checks APIs for associated VPC links, deletes the API, then prompts user if they also want to delete the associated VPC link and deletes accordingly. If and after the VPC links are deleted the function checks for full deletion of VPC links to avoid dependency errors with other resources. This has been implemented and tested for HTTP/websocket APIs. It has been implemented for REST APIs as well but still needs testing.
2. Adds a check for attached route tables before deleting subnets.
3. Fixes and improves clarity in ordering function.
4. Adds waiter to check for full deletion of ELBs
5. Standardizes and improves output syntax in terminal
6. Adds error handling for S3 buckets that have object lock enabled
7. Adds confirmation for TGs and listeners - A step is added for the delete_elb function to inform users that target groups and listeners will also be deleted and gives the option of opting out.
8. Also checks for TGs that might have multiple ELBs attached and returns without deleting. Only applicable for Network ELBs.
9. Adds additional functions for deleting listeners and TGs that are not attached to an ELB being deleted. 