### PR TITLE
feat: Adds create_dynamodb_table_backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ The plan is to gradually add more supported resources, but these are the resourc
 - EC2 Instances
 - EIPs
 - Internet Gateways
+- Launch Templates
 - NAT Gateways
 - Route Tables
+- Security Groups
 - Subnets
 - VPC Endpoints
 - VPCs

--- a/text_formatting.py
+++ b/text_formatting.py
@@ -22,6 +22,7 @@ class Format:
     green = '\033[32m'
     red = '\033[31m'
 
+
 def header_print(text: str, indent: int = 0) -> None:
     """
     Format text as a header and print it
@@ -34,6 +35,7 @@ def header_print(text: str, indent: int = 0) -> None:
     """
     print(Format.blue + ' ' * indent + text + Format.end)
     print()
+
 
 def subheader_print(text: str, indent: int=4) -> None:
     """
@@ -48,6 +50,7 @@ def subheader_print(text: str, indent: int=4) -> None:
     print(Format.cyan + ' ' * indent + text + Format.end)
     print()
 
+
 def indent_print(text: str, indent: int=4) -> None:
     """
     Indent text and print it
@@ -59,6 +62,7 @@ def indent_print(text: str, indent: int=4) -> None:
         indent (int, optional): Number of spaces to indent the text. Defaults to 4.
     """
     print(' ' * indent + text)
+
 
 def success_print(text: str, indent: int=4) -> None:
     """
@@ -72,6 +76,7 @@ def success_print(text: str, indent: int=4) -> None:
     """
     print(Format.green + ' ' * indent + text + Format.end)
 
+
 def failure_print(text: str, indent: int=4) -> None:
     """
     Format text as a failure message and print it
@@ -83,6 +88,7 @@ def failure_print(text: str, indent: int=4) -> None:
         indent (int, optional): Number of spaces to indent the text. Defaults to 4.
     """
     print(Format.red + ' ' * indent + text + Format.end)
+
 
 def response_print(text: str, indent: int=6) -> None:
     """
@@ -100,10 +106,12 @@ def response_print(text: str, indent: int=6) -> None:
         print(indent_str + line)
     print()
 
-def prompt(text: str, indent: int=4) -> str:
+
+def y_n_prompt(text: str, indent: int=4) -> str:
     """
     Format text as a prompt and return the user's response
 
+    For use with yes/no prompts.
     Accepts text and displays as a prompt, adding (y/n) at the end, then
     returns the user's response as a string. Defaults to an indent of 4 spaces.
 
@@ -115,6 +123,24 @@ def prompt(text: str, indent: int=4) -> str:
         str: Input from the user, stripped and lowercased.
     """
     return input(f"{' ' * indent}{text} (y/n): ").strip().lower()
+
+
+def custom_prompt(text: str, indent: int=4) -> str:
+    """
+    Format text as a prompt and return the user's response
+
+    Accepts text and displays as a prompt, then returns the user's response as a string.
+    Defaults to an indent of 4 spaces.
+
+    Args:
+        text (str): Text to display as a prompt
+        indent (int, optional): Number of spaced to indent the prompt text. Defaults to 4.
+
+    Returns:
+        str: Input from the user, stripped.
+    """
+    return input(f"{' ' * indent}{text}: ").strip()
+
 
 def warning_confirmation(text: str, indent: int=4) -> str:
     """


### PR DESCRIPTION
1. Adds create_dynamodb_table_backup which is called from delete_dynamodb_table if the table is not empty. The function prompts users if they would like to create a backup of the table and creates if they do.
2. Updates README to add launch templates and security groups to the list of supported resources